### PR TITLE
feat(controller): add controller for start-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+### Running Govern
+
+Pass the connection address as a flag (-addr) when starting the program. i.e. `go run govern.go -addr=<websocket address>`
 ### Twitch CLI Testing
 
 #### Prerequisite(s)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"govern/twitch/twitchclient"
+	"govern/twitch/twitchmessages"
+	"github.com/rs/zerolog/log"
+)
+
+// Channel to trigger reconnection logic
+var reconnectChan = make(chan string)
+
+// Controller that manages the WebSocket connection and message handling
+func StartController(initialAddr string) {
+	msgChannel := make(chan twitchmessages.BaseMessage)
+
+	// Start the WebSocket connection
+	go twitchclient.NewTwitchConnection(initialAddr, msgChannel)
+
+	// Handle incoming messages
+	go func() {
+		for {
+			msg := <-msgChannel
+			// Pass each message to the message handler
+			twitchmessages.MessageTypeHandler(msg, reconnectChan)
+		}
+	}()
+
+	// Monitor reconnection requests
+	for {
+		select {
+		case newAddr := <-reconnectChan:
+			log.Printf("Reconnecting to new address: %s", newAddr)
+			// Stop the current WebSocket connection and reconnect
+			twitchclient.NewTwitchConnection(newAddr, msgChannel)
+		}
+	}
+}

--- a/twitch/twitchclient/twitch_client.go
+++ b/twitch/twitchclient/twitch_client.go
@@ -1,85 +1,35 @@
 package twitchclient
 
 import (
-	"flag"
-	"govern/broker/messagebroker"
 	"govern/twitch/twitchmessages"
-	"net/url"
-	"os"
-	"os/signal"
-	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog/log"
 )
 
-var addr = flag.String("addr", "localhost:8080", "twitch-cli ws service address")
-
-func StartTwitchConnection(broker *messagebroker.Broker) bool {
-	flag.Parse()
-
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
-
-	u := url.URL{Scheme: "ws", Host: *addr, Path: "/ws"}
-	log.Info().Msgf("Main:Connection:Connecting to %s", u.String())
-
-	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
-	if err != nil {
-		log.Fatal().Msgf("Main:Connection:Dial:%v", err)
-	}
-	defer c.Close()
-
-	done := make(chan struct{})
-	timeout := 15 * time.Second //Likely need to adjust this based on session_start field.
-	// Create a channel to receive data
-	timerCh := make(chan bool)
-
-	go func() {
-		defer close(done)
-		for {
-			_, message, err := c.ReadMessage()
-			timerCh <- true
-			if err != nil {
-				log.Error().Msgf("Main:ReadMessage:Error:%v", err)
-				return
-			}
-			log.Trace().Msgf("Main:ReadMessage:RawMessage:%v", message)
-			// May need to add concurrency to the below message parsing/handler in the future.
-			converted_message, err := twitchmessages.ConvertToJson(message)
-			if err != nil {
-				// If we fail to parse message correctly we just log an error but processing continues.
-				log.Error().Msgf("Main:ConvertToJson:%v", err)
-			}
-			log.Info().Msgf("Main:ConvertToJson:Converted:%v", converted_message)
-			twitchmessages.MessageTypeHandler(converted_message, broker)
-		}
-	}()
-
+func NewTwitchConnection(addr string, msgChannel chan twitchmessages.BaseMessage) {
 	for {
-		select {
-		case <-timerCh:
-			log.Info().Msgf("Main:Connection:Timeout: Message recevied within set time-out: %v", timeout)
-		case <-time.After(timeout):
-			log.Info().Msgf("Main:Connection:Timeout: No message received within set time-out: %v", timeout)
-			return true
-		case <-done:
-			return false
-		case <-interrupt:
-			log.Info().Msg("Main:Connection:Interrupt occured, closing connection.")
+		u := addr
+		c, _, err := websocket.DefaultDialer.Dial(u, nil)
+		if err != nil {
+			log.Fatal().Msgf("twitchclient:newtwitchconnection:dial:%v", err)
+		}
+		defer c.Close()
+		log.Info().Msgf("twitchclient:newtwitchconnection: Successfully connected to %s", u)
 
-			// Cleanly close the connection by sending a close message and then
-			// waiting (with timeout) for the server to close the connection.
-			err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		for {
+			_, msg, err := c.ReadMessage()
 			if err != nil {
-				log.Error().Msgf("write close:%v", err)
-				return false
+				log.Error().Msgf("twitchclient:newtwitchconnection:read: Client disconnected due to %v:", err)
+				c.Close()
+				break
 			}
-			select {
-			case <-done:
-			case <-time.After(time.Second):
+			log.Info().Msgf("twitchclient:newtwitchconnection:read: Successfully received a message. Sending message to handler.")
+			converted_message, err := twitchmessages.ConvertToJson(msg)
+			if err != nil {
+				log.Error().Msgf("twitchclient:newtwitchconnection:convert: Failed to convert message to JSON due to: %v", err)
 			}
-			return false
+			msgChannel <- converted_message
 		}
 	}
 }


### PR DESCRIPTION
Adding a controller for use during start-up so when a reconnect message is parsed the program will not exit instead connects to the given reconnect url.